### PR TITLE
Link fix and dependency update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
     neat (3.0.1)
       sass (~> 3.4)
       thor (~> 0.19)
-    nokogiri (1.10.4)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)
     pathutil (0.16.2)

--- a/src/index.html
+++ b/src/index.html
@@ -61,7 +61,7 @@ title: Defense Digital Service
       <div class="section-rule"></div>
       <h2>Apply to DDS</h2>
       <p>The best of technology. The best of government—and we need you.</p>
-      <a class="join-button" href="mailto:Rebel@dds.mil">Contact Us</a>
+      <a class="join-button" href="mailto:Rebel@dds.mil?subject=I%20want%20to%20join!">Contact Us</a>
     </div>
   </div>
 </section>
@@ -72,7 +72,7 @@ title: Defense Digital Service
       <div class="section-rule"></div>
       <h2>Our partners</h2>
       <p>We work alongside service members and civil servants across the Defense Department. DOD civilians and military members with technical expertise can apply to work with DDS on short-term details.</p>
-      <a class="join-button" href="https://hire.withgoogle.com/public/jobs/ddsmil/view/P_AAAAAAEAAF3KkxWUnRXoHq">TDY to DDS</a>
+      <a class="join-button" href="mailto:Rebel@dds.mil?subject=I%20want%20to%20TDY%20to%20DDS!">TDY to DDS</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Hey folks, we had to update the nokogiri library based on a security vuln. The build won't finish because the link to Google Hire is broken because we aren't using it any more. So, I also updated the link on the "TDY with DDS" button to just use email (mailto link).