### PR TITLE
adds public folder path which replaces relative paths for image in markdown

### DIFF
--- a/src/cms/posts.tsx
+++ b/src/cms/posts.tsx
@@ -20,6 +20,7 @@ export const PostCollection: CmsCollection = {
   label_singular: "Blog Post",
   description: "Blog Posts from the DDS team.",
   folder: "content/posts",
+  public_folder: "",
   slug: "{{year}}-{{month}}-{{slug}}",
   summary: entrySummaryFormat,
   create: true,


### PR DESCRIPTION
New blogposts were failing as netlify referenced the relative path to image resources added through its ui in blogpost markdown. Specifying `public_folder` on the blog post collection prevents this behavior. 

I tested locally by changing netlifys config to point to my local git repo (https://www.netlifycms.org/docs/beta-features/) and new posts were rendered without manually editing the image path. 