### PR TITLE
Patched 🐛 CVE-2020-28502

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7210,7 +7210,7 @@
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
         "ws": "~6.1.0",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       },
       "dependencies": {


### PR DESCRIPTION
This affects the package xmlhttprequest before 1.7.0; all versions of package xmlhttprequest-ssl. Provided requests are sent synchronously (async=False on xhr.open), malicious user input flowing into xhr.send could result in arbitrary code being injected and run.

`Severity High`  
GHSA-h4j5-c7cj-74xg
