### PR TITLE
Patched🐛 Insecure defaults due to CORS misconfiguration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8949,8 +8949,8 @@
         "shallow-compare": "^1.2.2",
         "signal-exit": "^3.0.3",
         "slugify": "^1.4.4",
-        "socket.io": "^2.3.0",
-        "socket.io-client": "2.3.0",
+        "socket.io": "^2.4.0",
+        "socket.io-client": "2.4.0",
         "st": "^2.0.0",
         "stack-trace": "^0.0.10",
         "string-similarity": "^1.2.2",
@@ -20025,15 +20025,15 @@
       }
     },
     "socket.io": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.3.0.tgz",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.4.0.tgz",
       "integrity": "sha512-2A892lrj0GcgR/9Qk81EaY2gYhCBxurV0PfmmESO6p27QPrUK1J3zdns+5QPqvUYK2q657nSj0guoIil9+7eFg==",
       "requires": {
         "debug": "~4.1.0",
         "engine.io": "~3.4.0",
         "has-binary2": "~1.0.2",
         "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.3.0",
+        "socket.io-client": "2.4.0",
         "socket.io-parser": "~3.4.0"
       },
       "dependencies": {
@@ -20053,7 +20053,7 @@
       "integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g=="
     },
     "socket.io-client": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
       "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
       "requires": {


### PR DESCRIPTION
The package socket.io before 2.4.0 are vulnerable to Insecure Defaults due to CORS Misconfiguration. All domains are whitelisted by default.

**CVE-2020-28481**
`Severity Moderate`
GHSA-fxwf-4rqh-v8g3
