### PR TITLE
Patched 🐛Remote Memory Exposure in bl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3993,7 +3993,7 @@
       }
     },
     "bl": {
-      "version": "4.0.2",
+      "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
       "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
       "requires": {
@@ -20473,7 +20473,7 @@
       "integrity": "sha512-drN+aGYnrZPNYIymmNwIY7LXYJ8MqsqXj4fMRue3FOgGMdGjSX10fhJ3qx0sVQPhcWxhEaN4U/eWM4O4dbYNAw==",
       "requires": {
         "async-cache": "^1.1.0",
-        "bl": "^4.0.0",
+        "bl": "^4.0.3",
         "fd": "~0.0.2",
         "graceful-fs": "^4.2.3",
         "mime": "^2.4.4",
@@ -21030,7 +21030,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
       "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
       "requires": {
-        "bl": "^4.0.1",
+        "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
         "inherits": "^2.0.3",


### PR DESCRIPTION
A buffer over-read vulnerability exists in bl <4.0.3, <3.0.1, <2.2.1, and <1.2.3 which could allow an attacker to supply user input (even typed) that if it ends up in consume() argument and can become negative, the BufferList state can be corrupted, tricking it into exposing uninitialized memory via regular .slice() calls.

**CVE-2020-8244**
`6.5/ 10`
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L`