### PR TITLE
Patched 🐛 Arbitrary Code Execution in underscore 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19781,7 +19781,7 @@
       "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-1.13.0.tgz",
       "integrity": "sha1-Vpy+IYAgKSamKiZs094Jyc60P4M=",
       "requires": {
-        "underscore": "^1.7.0",
+        "underscore": "^1.12.1",
         "url-join": "^1.1.0"
       }
     },
@@ -21532,7 +21532,7 @@
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
     "underscore": {
-      "version": "1.10.2",
+      "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
       "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
     },


### PR DESCRIPTION
The package `underscore` from 1.13.0-0 and before 1.13.0-2, from 1.3.2 and before 1.12.1 are vulnerable to Arbitrary Code Execution via the template function, particularly when a variable property is passed as an argument as it is not sanitized.

**CVE-2021-23358**
`GHSA-cf4h-3jhx-xvhq`