### PR TITLE
Patched 🐛 Command Injection in lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -171,7 +171,7 @@
       "requires": {
         "@babel/helper-function-name": "^7.10.4",
         "@babel/types": "^7.10.5",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -236,7 +236,7 @@
         "@babel/helper-split-export-declaration": "^7.11.0",
         "@babel/template": "^7.10.4",
         "@babel/types": "^7.11.0",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -257,7 +257,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
       "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
       "requires": {
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -1121,7 +1121,7 @@
         "@babel/types": "^7.11.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "lodash": "^4.17.21"
       },
       "dependencies": {
         "@babel/code-frame": {
@@ -1163,7 +1163,7 @@
       "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
@@ -1843,7 +1843,7 @@
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.1",
             "json5": "^2.1.2",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.21",
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
             "source-map": "^0.5.0"
@@ -2583,7 +2583,7 @@
         "eslint-visitor-keys": "^1.1.0",
         "glob": "^7.1.6",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
       },
@@ -4702,7 +4702,7 @@
         "dom-serializer": "~0.1.1",
         "entities": "~1.1.1",
         "htmlparser2": "^3.9.1",
-        "lodash": "^4.15.0",
+        "lodash": "^4.17.21",
         "parse5": "^3.0.1"
       },
       "dependencies": {
@@ -5275,7 +5275,7 @@
       "requires": {
         "chalk": "^2.4.2",
         "date-fns": "^2.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "read-pkg": "^4.0.1",
         "rxjs": "^6.5.2",
         "spawn-command": "^0.0.2-1",
@@ -5423,7 +5423,7 @@
       "requires": {
         "axios": "^0.19.0",
         "contentful-sdk-core": "^6.4.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "type-fest": "0.15.1"
       },
       "dependencies": {
@@ -5439,7 +5439,7 @@
       "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.4.5.tgz",
       "integrity": "sha512-rygNuiwbG6UKrJg6EDlaKewayTeLWrjA2wJwVmq7rV/DYo0cic6t28y0EMhRQ4pgJDV5HyUQFoFeBm2lwLfG2Q==",
       "requires": {
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.21",
         "qs": "^6.5.2"
       }
     },
@@ -5971,7 +5971,7 @@
         "css-selector-tokenizer": "^0.7.0",
         "icss-utils": "^2.1.0",
         "loader-utils": "^1.0.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "postcss": "^6.0.23",
         "postcss-modules-extract-imports": "^1.2.0",
         "postcss-modules-local-by-default": "^1.2.0",
@@ -6645,7 +6645,7 @@
         "eol": "^0.9.1",
         "get-port": "^3.2.0",
         "glob": "^7.1.2",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.21",
         "mkdirp": "^0.5.1",
         "password-prompt": "^1.0.4",
         "rimraf": "^2.6.2",
@@ -7381,7 +7381,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.14",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
@@ -7592,7 +7592,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.13.0.tgz",
       "integrity": "sha512-bhewp36P+t7cEV0b6OdmoRWJCBYRiHFlqPZAG1oS3SF+Y0LQkeDvFSM4oxoxvczD1OdONCXMlJfQFiWLcV9urw==",
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       }
     },
     "eslint-plugin-graphql": {
@@ -7601,7 +7601,7 @@
       "integrity": "sha512-VNu2AipS8P1BAnE/tcJ2EmBWjFlCnG+1jKdUlFNDQjocWZlFiPpMu9xYNXePoEXK+q+jG51M/6PdhOjEgJZEaQ==",
       "requires": {
         "graphql-config": "^2.0.1",
-        "lodash": "^4.11.1"
+        "lodash": "^4.17.21"
       }
     },
     "eslint-plugin-import": {
@@ -8700,7 +8700,7 @@
       "requires": {
         "deepmerge": "^2.1.1",
         "hoist-non-react-statics": "^3.3.0",
-        "lodash": "^4.17.14",
+        "lodash": "^4.17.21",
         "lodash-es": "^4.17.14",
         "react-fast-compare": "^2.0.1",
         "scheduler": "^0.18.0",
@@ -8915,7 +8915,7 @@
         "json-loader": "^0.5.7",
         "json-stringify-safe": "^5.0.1",
         "latest-version": "5.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "md5-file": "^3.2.3",
         "meant": "^1.0.1",
         "micromatch": "^3.1.10",
@@ -9091,7 +9091,7 @@
             "ink": "^2.7.1",
             "ink-spinner": "^3.1.0",
             "is-valid-path": "^0.1.1",
-            "lodash": "^4.17.15",
+            "lodash": "^4.17.21",
             "meant": "^1.0.1",
             "node-fetch": "^2.6.0",
             "opentracing": "^0.14.4",
@@ -9409,7 +9409,7 @@
         "fs-exists-cached": "^1.0.0",
         "gatsby-core-utils": "^1.3.15",
         "glob": "^7.1.6",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "micromatch": "^3.1.10"
       },
       "dependencies": {
@@ -9478,7 +9478,7 @@
         "html-webpack-exclude-assets-plugin": "^0.0.7",
         "html-webpack-plugin": "^3.2.0",
         "html-webpack-tags-plugin": "^2.0.17",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "mini-css-extract-plugin": "^0.8.2",
         "netlify-identity-widget": "^1.6.0",
         "webpack": "^4.43.0"
@@ -9494,7 +9494,7 @@
         "gatsby-page-utils": "^0.2.20",
         "globby": "^11.0.1",
         "graphql": "^14.6.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "slugify": "^1.4.4"
       },
       "dependencies": {
@@ -9611,7 +9611,7 @@
         "imagemin": "^6.1.0",
         "imagemin-mozjpeg": "^8.0.0",
         "imagemin-pngquant": "^6.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "mini-svg-data-uri": "^1.2.3",
         "potrace": "^2.1.8",
         "probe-image-size": "^4.1.1",
@@ -9635,7 +9635,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
           "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "requires": {
-            "lodash": "^4.17.14"
+            "lodash": "^4.17.21"
           }
         },
         "semver": {
@@ -9769,7 +9769,7 @@
         "isomorphic-fetch": "^2.1.0",
         "jest-diff": "^25.5.0",
         "lock": "^1.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "mitt": "^1.2.0",
         "mkdirp": "^0.5.1",
         "node-fetch": "^2.5.0",
@@ -9990,7 +9990,7 @@
         "cheerio": "^1.0.0-rc.3",
         "gatsby-core-utils": "^1.3.15",
         "is-relative-url": "^3.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "mdast-util-definitions": "^1.2.5",
         "potrace": "^2.1.8",
         "query-string": "^6.13.1",
@@ -10045,7 +10045,7 @@
         "@babel/runtime": "^7.10.3",
         "cheerio": "^1.0.0-rc.3",
         "common-tags": "^1.8.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "unist-util-visit": "^1.4.1"
       },
       "dependencies": {
@@ -10152,7 +10152,7 @@
         "gatsby-core-utils": "^1.3.15",
         "git-up": "4.0.1",
         "is-docker": "2.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "node-fetch": "2.6.0",
         "uuid": "3.4.0"
       },
@@ -10230,7 +10230,7 @@
         "gray-matter": "^4.0.2",
         "hast-util-raw": "^4.0.0",
         "hast-util-to-html": "^4.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "mdast-util-to-hast": "^3.0.4",
         "mdast-util-to-string": "^1.1.0",
         "mdast-util-toc": "^5.0",
@@ -10987,7 +10987,7 @@
       "integrity": "sha512-OVyWOHgw29yosRHCHo7NncwR1hW5ew0W/UrvtwvjefVJeQ26q4/8r8FmPsSF1hJ93IgWkyv16pCTz6WblMzm/g==",
       "requires": {
         "glob": "~7.1.1",
-        "lodash": "~4.17.12",
+        "lodash": "~4.17.21",
         "minimatch": "~3.0.2"
       }
     },
@@ -11136,7 +11136,7 @@
         "graphql-import": "^0.7.1",
         "graphql-request": "^1.5.0",
         "js-yaml": "^3.10.0",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4"
       }
     },
@@ -11145,7 +11145,7 @@
       "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.7.1.tgz",
       "integrity": "sha512-YpwpaPjRUVlw2SN3OPljpWbVRWAhMAyfSba5U47qGMOSsPLi2gYeJtngGpymjm9nk57RFWEpjqwh4+dpYuFAPw==",
       "requires": {
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.21",
         "resolve-from": "^4.0.0"
       }
     },
@@ -11748,7 +11748,7 @@
       "requires": {
         "html-minifier": "^3.2.3",
         "loader-utils": "^0.2.16",
-        "lodash": "^4.17.3",
+        "lodash": "^4.17.21",
         "pretty-error": "^2.0.2",
         "tapable": "^1.0.0",
         "toposort": "^1.0.0",
@@ -11895,7 +11895,7 @@
       "requires": {
         "http-proxy": "^1.17.0",
         "is-glob": "^4.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "micromatch": "^3.1.10"
       }
     },
@@ -12586,7 +12586,7 @@
         "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
         "rxjs": "^6.6.0",
@@ -13516,7 +13516,7 @@
       "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
       "integrity": "sha512-7KI2l2GIZa9p2spzPIVZBYyNKkN+e/SQPpnjlTiPhdbDW3F86tdKKELxKpzJ5sgU19wQWsACULZmpTPYHeWO5w==",
       "requires": {
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.21",
         "webpack-sources": "^1.1.0"
       }
     },
@@ -13713,7 +13713,7 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
+      "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
@@ -14646,7 +14646,7 @@
         "@emotion/core": "^10.0.9",
         "@emotion/styled": "^10.0.9",
         "immutable": "^3.7.6",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "moment": "^2.24.0",
         "netlify-cms-backend-bitbucket": "^2.12.1",
         "netlify-cms-backend-git-gateway": "^2.11.1",
@@ -15279,7 +15279,7 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.13.2",
@@ -16323,7 +16323,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
           "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "requires": {
-            "lodash": "^4.17.14"
+            "lodash": "^4.17.21"
           }
         }
       }
@@ -18326,7 +18326,7 @@
             "create-react-class": "^15.5.1",
             "hoist-non-react-statics": "^3.3.0",
             "invariant": "^2.0.0",
-            "lodash": "^4.17.11",
+            "lodash": "^4.17.21",
             "loose-envify": "^1.4.0",
             "prop-types": "^15.7.2"
           }
@@ -18732,7 +18732,7 @@
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.1",
             "json5": "^2.1.2",
-            "lodash": "^4.17.19",
+            "lodash": "^4.17.21",
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
             "source-map": "^0.5.0"
@@ -19234,7 +19234,7 @@
       "integrity": "sha512-79tcPlgJ3fuK0/TtUCIBdPeQSvktTSTJP9O/dzrteaO98qw5UV6CATh3ZyPjUzv1LtNjHDlhbq9XOXiKf0zA1w==",
       "requires": {
         "htmlparser2": "^4.1.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "parse-srcset": "^1.0.2",
         "postcss": "^7.0.27"
       },
@@ -19799,7 +19799,7 @@
         "direction": "^0.1.5",
         "esrever": "^0.2.0",
         "is-plain-object": "^2.0.4",
-        "lodash": "^4.17.4",
+        "lodash": "^4.17.21",
         "tiny-invariant": "^1.0.1",
         "tiny-warning": "^0.0.3",
         "type-of": "^2.0.1"
@@ -20964,7 +20964,7 @@
       "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "requires": {
         "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
+        "lodash": "^4.17.21",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
       },
@@ -22603,7 +22603,7 @@
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
       "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21"
       }
     },
     "webpack-sources": {
@@ -23018,7 +23018,7 @@
       "requires": {
         "@babel/runtime": "^7.0.0",
         "fn-name": "~2.0.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.21",
         "property-expr": "^1.5.0",
         "synchronous-promise": "^2.0.6",
         "toposort": "^2.0.2"


### PR DESCRIPTION
`lodash` versions prior to 4.17.21 are vulnerable to Command Injection via the template function.

**CVE-2021-23337**
`7.2/ 10`
CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
